### PR TITLE
Fix assumptions about tag keys and empty tag values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.14
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/golang/protobuf v1.3.2
+	github.com/google/go-cmp v0.3.0
 	go.opencensus.io v0.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,14 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/transform_stats_to_metrics.go
+++ b/transform_stats_to_metrics.go
@@ -177,7 +177,7 @@ func viewDataToTimeseries(vd *view.Data) ([]*metricspb.TimeSeries, error) {
 	for _, row := range vd.Rows {
 		labelValues, err := labelValuesFromTags(row.Tags, keysToColumns)
 		if err != nil {
-			return nil, fmt.Errorf("Label values from tags: %v", err)
+			return nil, err
 		}
 		point := rowToPoint(vd.View, row, endTimestamp, mType)
 		timeseries = append(timeseries, &metricspb.TimeSeries{
@@ -277,7 +277,7 @@ func labelValuesFromTags(tags []tag.Tag, keysToColumns map[string]int) ([]*metri
 	for _, tag_ := range tags {
 		i, ok := keysToColumns[tag_.Key.Name()]
 		if !ok {
-			return nil, fmt.Errorf("No tag key named %q", tag_.Key.Name())
+			return nil, fmt.Errorf("no tag key named %q", tag_.Key.Name())
 		}
 		labelValues[i].Value = tag_.Value
 		labelValues[i].HasValue = true

--- a/transform_stats_to_metrics_test.go
+++ b/transform_stats_to_metrics_test.go
@@ -1077,6 +1077,36 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 	}
 
 	tests := []*test{
+		{
+			in: &view.Data{
+				Start: startTime,
+				End:   endTime,
+				View: &view.View{
+					Name:        "ocagent.io/counts",
+					Description: "count of runners for a 100m dash",
+					Aggregation: view.Count(),
+					TagKeys:     []tag.Key{keyField, keyName},
+					Measure:     mSprinterLatencyMs,
+				},
+				Rows: []*view.Row{
+					{
+						Tags: []tag.Tag{
+							{Key: keyField, Value: "small-field"},
+							{Key: keyName, Value: "sprints"},
+						},
+						Data: &view.CountData{Value: 25},
+					},
+					{
+						Tags: []tag.Tag{
+							{Key: keyName, Value: "sprinter-#10"},
+							{Key: keyPlayerName, Value: "some-player"},
+						},
+						Data: &view.CountData{Value: 10},
+					},
+				},
+			},
+			wantErr: "no tag key named: \"player_name\"",
+		},
 		// Testing with a stats.Float64 measure.
 		{
 			in: vd,

--- a/transform_stats_to_metrics_test.go
+++ b/transform_stats_to_metrics_test.go
@@ -15,11 +15,12 @@
 package ocagent
 
 import (
-	"encoding/json"
-	"reflect"
+	"context"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -27,6 +28,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -758,7 +760,7 @@ func TestViewDataToMetrics_Count(t *testing.T) {
 						Tags: []tag.Tag{
 							{Key: keyField, Value: "main-field"},
 							{Key: keyName, Value: "sprinter-#10"},
-							{Key: keyName, Value: "player_1"},
+							{Key: keyPlayerName, Value: "player_1"},
 						},
 						Data: &view.CountData{Value: 3},
 					},
@@ -766,7 +768,7 @@ func TestViewDataToMetrics_Count(t *testing.T) {
 						Tags: []tag.Tag{
 							{Key: keyField, Value: "small-field"},
 							{Key: keyName, Value: "sprints"},
-							{Key: keyName, Value: "player_2"},
+							{Key: keyPlayerName, Value: "player_2"},
 						},
 						Data: &view.CountData{Value: 1},
 					},
@@ -944,7 +946,7 @@ func TestViewDataToMetrics_Sum(t *testing.T) {
 						Tags: []tag.Tag{
 							{Key: keyField, Value: "main-field"},
 							{Key: keyName, Value: "sprinter-#10"},
-							{Key: keyName, Value: "player_1"},
+							{Key: keyPlayerName, Value: "player_1"},
 						},
 						Data: &view.SumData{Value: 3},
 					},
@@ -952,7 +954,7 @@ func TestViewDataToMetrics_Sum(t *testing.T) {
 						Tags: []tag.Tag{
 							{Key: keyField, Value: "small-field"},
 							{Key: keyName, Value: "sprints"},
-							{Key: keyName, Value: "player_2"},
+							{Key: keyPlayerName, Value: "player_2"},
 						},
 						Data: &view.SumData{Value: 1},
 					},
@@ -1024,30 +1026,60 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 	startTime := time.Date(2018, 11, 25, 15, 38, 18, 997, time.UTC)
 	endTime := startTime.Add(100 * time.Millisecond)
 
+	latencyView := &view.View{
+		Name:        "ocagent.io/latency",
+		Description: "speed of the various runners",
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{keyField, keyName, keyPlayerName},
+		Measure:     mSprinterLatencyMs,
+	}
+
+	view.Register(latencyView)
+	defer view.Unregister(latencyView)
+
+	stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(keyField, "main-field"),
+		tag.Upsert(keyName, "sprint-1"),
+		tag.Upsert(keyPlayerName, "player-1"),
+	}, mSprinterLatencyMs.M(2))
+	stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(keyField, "main-field"),
+		// Missing Sprint Name
+		tag.Upsert(keyPlayerName, "player-2"),
+	}, mSprinterLatencyMs.M(4))
+	stats.RecordWithTags(context.Background(), []tag.Mutator{
+		tag.Upsert(keyField, ""), // Empty field name
+		tag.Upsert(keyName, ""),  // Empty sprint name
+		// Duplicate tag values. Only the most recent tag value should be used.
+		tag.Upsert(keyPlayerName, "player-x"),
+		tag.Upsert(keyPlayerName, "player-3"),
+	}, mSprinterLatencyMs.M(6))
+	stats.RecordWithTags(context.Background(), []tag.Mutator{}, mSprinterLatencyMs.M(8))
+
+	rows, err := view.RetrieveData(latencyView.Name)
+	if err != nil {
+		t.Fatalf("Error retrieving view data: %v", err)
+	}
+
+	// Ordering of rows might be different from the order in which they were
+	// recorded. Sorting them by recorded measurement values for comparison.
+	sort.SliceStable(rows, func(i, j int) bool {
+		l := rows[i].Data.(*view.SumData)
+		r := rows[j].Data.(*view.SumData)
+		return l.Value < r.Value
+	})
+
+	vd := &view.Data{
+		View:  latencyView,
+		Start: startTime,
+		End:   endTime,
+		Rows:  rows,
+	}
+
 	tests := []*test{
 		// Testing with a stats.Float64 measure.
 		{
-			in: &view.Data{
-				Start: startTime,
-				End:   endTime,
-				View: &view.View{
-					Name:        "ocagent.io/latency",
-					Description: "speed of the various runners",
-					Aggregation: view.Sum(),
-					TagKeys:     []tag.Key{keyField, keyName, keyPlayerName},
-					Measure:     mSprinterLatencyMs,
-				},
-				Rows: []*view.Row{
-					{
-						Tags: []tag.Tag{
-							{}, // Testing a missing tag
-							{Key: keyName, Value: "sprinter-#10"},
-							{Key: keyPlayerName, Value: ""},
-						},
-						Data: &view.SumData{Value: 27},
-					},
-				},
-			},
+			in: vd,
 			want: &metricspb.Metric{
 				MetricDescriptor: &metricspb.MetricDescriptor{
 					Name:        "ocagent.io/latency",
@@ -1067,9 +1099,9 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 							Nanos:   997,
 						},
 						LabelValues: []*metricspb.LabelValue{
-							{Value: "", HasValue: false},
-							{Value: "sprinter-#10", HasValue: true},
-							{Value: "", HasValue: true},
+							{Value: "main-field", HasValue: true},
+							{Value: "sprint-1", HasValue: true},
+							{Value: "player-1", HasValue: true},
 						},
 						Points: []*metricspb.Point{
 							{
@@ -1077,59 +1109,19 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 									Seconds: 1543160298,
 									Nanos:   100000997,
 								},
-								Value: &metricspb.Point_DoubleValue{DoubleValue: 27},
+								Value: &metricspb.Point_DoubleValue{DoubleValue: 2},
 							},
 						},
 					},
-				},
-			},
-		},
-
-		// Testing with a stats.Int64 measure.
-		{
-			in: &view.Data{
-				Start: startTime,
-				End:   endTime,
-				View: &view.View{
-					Name:        "ocagent.io/fouls",
-					Description: "the number of fouls by players",
-					Aggregation: view.Sum(),
-					TagKeys:     []tag.Key{keyField, keyName, keyPlayerName},
-					Measure:     mFouls,
-				},
-				Rows: []*view.Row{
-					{
-						Tags: []tag.Tag{
-							{},
-							{Key: keyName, Value: "player_1"},
-							{Key: keyField, Value: ""},
-						},
-						Data: &view.SumData{Value: 3},
-					},
-				},
-			},
-			want: &metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "ocagent.io/fouls",
-					Description: "the number of fouls by players",
-					Unit:        "1",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "field"},
-						{Key: "name"},
-						{Key: "player_name"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
 					{
 						StartTimestamp: &timestamp.Timestamp{
 							Seconds: 1543160298,
 							Nanos:   997,
 						},
 						LabelValues: []*metricspb.LabelValue{
-							{Value: "", HasValue: false},
-							{Value: "player_1", HasValue: true},
-							{Value: "", HasValue: true},
+							{Value: "main-field", HasValue: true},
+							{HasValue: false},
+							{Value: "player-2", HasValue: true},
 						},
 						Points: []*metricspb.Point{
 							{
@@ -1137,12 +1129,51 @@ func TestViewDataToMetrics_MissingVsEmptyLabelValues(t *testing.T) {
 									Seconds: 1543160298,
 									Nanos:   100000997,
 								},
-								Value: &metricspb.Point_Int64Value{Int64Value: 3},
+								Value: &metricspb.Point_DoubleValue{DoubleValue: 4},
+							},
+						},
+					},
+					{
+						StartTimestamp: &timestamp.Timestamp{
+							Seconds: 1543160298,
+							Nanos:   997,
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{HasValue: false},
+							{HasValue: false},
+							{Value: "player-3", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 1543160298,
+									Nanos:   100000997,
+								},
+								Value: &metricspb.Point_DoubleValue{DoubleValue: 6},
+							},
+						},
+					},
+					{
+						StartTimestamp: &timestamp.Timestamp{
+							Seconds: 1543160298,
+							Nanos:   997,
+						},
+						LabelValues: []*metricspb.LabelValue{
+							{HasValue: false},
+							{HasValue: false},
+							{HasValue: false},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 1543160298,
+									Nanos:   100000997,
+								},
+								Value: &metricspb.Point_DoubleValue{DoubleValue: 8},
 							},
 						},
 					},
 				},
-				Resource: nil,
 			},
 		},
 	}
@@ -1167,17 +1198,8 @@ func testViewDataToMetrics(t *testing.T, tests []*test) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, tt.want) {
-			gj := serializeAsJSON(got)
-			wj := serializeAsJSON(tt.want)
-			if gj != wj {
-				t.Errorf("#%d: Unmatched JSON\nGot:\n\t%s\nWant:\n\t%s", i, gj, wj)
-			}
+		if diff := cmp.Diff(tt.want, got, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("metric mismatch (-want +got):\n%v", diff)
 		}
 	}
-}
-
-func serializeAsJSON(v interface{}) string {
-	blob, _ := json.MarshalIndent(v, "", "  ")
-	return string(blob)
 }


### PR DESCRIPTION
Opencensus while exporting view data, does not include tags that are not recorded or whose value is is an empty string `""`.  Also in the exported view data there can be multiple data rows, each of which can have different number of tags. The number of tags in each data row is equal to or less that the number of tags listed in the view definition. 

`ocagentconv` has the following assumptions that are incorrect
1. The number of tags and ordering of the tags in a data row is same as the number of tags in the view definition. https://github.com/orijtech/ocagentconv/blob/b9713536afcf83d3f50df6fec9d54179c9e1f621/transform_stats_to_metrics.go#L257-L272
2. Tags that does not have values has an empty string for the key name
https://github.com/orijtech/ocagentconv/blob/b9713536afcf83d3f50df6fec9d54179c9e1f621/transform_stats_to_metrics.go#L270
3. There can be tags whose value is an empty string ""

This pull request addresses these assumption by constructing the label values based on the ordering of the tag keys. 

Fixes https://github.com/orijtech/ocagentconv/issues/4